### PR TITLE
Add doctrine ORM Mapping files for Money objects

### DIFF
--- a/Infrastructure/doctrine/Money/Currency.orm.xml
+++ b/Infrastructure/doctrine/Money/Currency.orm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                         http://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <embeddable name="Randock\ValueObject\Money\Currency" >
+        <field name="currencyCode" type="string" column="currency_code"/>
+    </embeddable>
+
+</doctrine-mapping>

--- a/Infrastructure/doctrine/Money/ExchangeRate.orm.xml
+++ b/Infrastructure/doctrine/Money/ExchangeRate.orm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                         http://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <embeddable name="Randock\ValueObject\Money\ExchangeRate">
+        <field name="rate" type="float"/>
+        <embedded name="source" class="Randock\ValueObject\Money\Currency"/>
+        <embedded name="target" class="Randock\ValueObject\Money\Currency"/>
+    </embeddable>
+
+</doctrine-mapping>

--- a/Infrastructure/doctrine/Money/Money.orm.xml
+++ b/Infrastructure/doctrine/Money/Money.orm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                         http://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+    <embeddable name="Randock\ValueObject\Money\Money" >
+        <field name="amount" column="amount" type="float"/>
+        <embedded name="currency" class="Randock\ValueObject\Money\Currency" use-column-prefix="false" />
+    </embeddable>
+
+</doctrine-mapping>


### PR DESCRIPTION
In order to reuse mapping file across projects.
They are only a subset of classes, but i can add the rest of files.

It's possible also auto mapping entities distributing ValueObject library as a Symfony Bundle, but providing xml files is enough